### PR TITLE
Enable `rkyv` `std` feature only if `rkyv` is active

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -19,4 +19,4 @@ rkyv = { version = "0.7", optional = true, default-features = false, features = 
 [features]
 default = ["std"]
 pg = ["postgres-types", "bytes"]
-std = ["rkyv/std"]
+std = ["rkyv?/std"]


### PR DESCRIPTION
We've been having compilation issues in Kitsune because of the `rkyv` feature.  

Since the `std` feature is enabled by default, it will start to pull in `rkyv` without any `size_*` feature enabled, resulting in compilation errors (since we don't use `rkyv` anywhere downstream).  
This patch simply adds the `?` to the feature, only enabling in the `std` feature if `rkyv` is already getting pulled in.